### PR TITLE
Update faq.txt

### DIFF
--- a/faq.txt
+++ b/faq.txt
@@ -141,14 +141,11 @@ Q: Why do my apps keep crashing (1)?
 
 A:
 If it crashes with Illegal Instruction: 4, then it's because they are 32-bit apps, which do not work with the AMD OS X patches.
-▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬
-Q: Why do my apps keep crashing (2)?
 
-A:
 Certain apps that use Intel MKL libraries (Intel OneAPI) may crash on AMD, but it is possible to redirect calls to this API to AMD-compatible ones.
 Apps like Adobe CC suite, Autodesk Maya, Autodesk Autocad, Matlab, Discord, Waves plugin set, Krisp AI, Neo Luminar and many others may be affected.
 Check this thread to see update on patched apps: https://www.macos86.it/topic/5479-amd-new-applications-life/ 
-Or check this thread to learn "How to...":
+Or check this thread for a tutorial on how to patch these apps yourself:
 https://www.macos86.it/topic/5489-tutorial-for-patching-binaries-for-amd-hackintosh-compatibility/
 Credit for this goes to @tomnic.
 ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬

--- a/faq.txt
+++ b/faq.txt
@@ -137,13 +137,19 @@ A:
 Your SMBIOS information is incorrect. For AMD, MacPro7,1 is best for Catalina and up. If you want to run High Sierra or Mojave, iMacPro1,1 is the best choice.
 Do not use the -no_compat_check boot argument.
 ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬ 
-Q: Why do my apps keep crashing?
+Q: Why do my apps keep crashing (1)?
 
 A:
 If it crashes with Illegal Instruction: 4, then it's because they are 32-bit apps, which do not work with the AMD OS X patches.
+▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬
+Q: Why do my apps keep crashing (2)?
+
+A:
 Certain apps that use Intel MKL libraries (Intel OneAPI) may crash on AMD, but it is possible to redirect calls to this API to AMD-compatible ones.
 Apps like Adobe CC suite, Autodesk Maya, Autodesk Autocad, Matlab, Discord, Waves plugin set, Krisp AI, Neo Luminar and many others may be affected.
 Check this thread to see update on patched apps: https://www.macos86.it/topic/5479-amd-new-applications-life/ 
+Or check this thread to learn "How to...":
+https://www.macos86.it/topic/5489-tutorial-for-patching-binaries-for-amd-hackintosh-compatibility/
 Credit for this goes to @tomnic.
 ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬
 Q: How do I fix my USB ports not working?


### PR DESCRIPTION
@tomnic79 creates a thread on macoOS86.it to explain how to patch every apps which use infamous Intel MKL libraries or __intel_fast_memset.A and __intel_fast_memcpy.A.